### PR TITLE
[BETA RELEASE] 11-23-17

### DIFF
--- a/src/components/ChipBar/ChipBar.jsx
+++ b/src/components/ChipBar/ChipBar.jsx
@@ -1,0 +1,34 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { withRouter } from 'react-router-dom';
+import Chip from 'material-ui/Chip';
+
+class ChipBar extends Component {
+  handleTouchTap = () => {
+    const { id, type } = this.props;
+    this.props.history.push(`/log-overview/${id}/?type=${type}`);
+  }
+
+  render() {
+    const { player } = this.props;
+    return (
+      <div>
+        <Chip
+          onRequestDelete={this.handleTouchTap}
+        >
+          {player}
+        </Chip>
+      </div>
+    );
+  }
+}
+
+const { string, shape } = PropTypes;
+ChipBar.propTypes = {
+  player: string,
+  type: string,
+  id: string,
+  history: shape({}),
+};
+
+export default withRouter(ChipBar);

--- a/src/components/ChipBar/index.js
+++ b/src/components/ChipBar/index.js
@@ -1,0 +1,3 @@
+import ChipBar from './ChipBar';
+
+export default ChipBar;

--- a/src/components/Log/DamageDetails/DamageDetails.jsx
+++ b/src/components/Log/DamageDetails/DamageDetails.jsx
@@ -7,11 +7,14 @@ import moment from 'moment';
 import PlayerHeader from '../../PlayerHeader';
 import SubNavbar from '../../SubNavbar';
 import Percent from '../../Visualizations/Percent';
+import DamageDoneChart from '../../Visualizations/DamageDoneChart';
 import Table from '../../Table';
+import ChipBar from '../../ChipBar';
 
 import constants from '../../constants';
 import { getLogFilteredByUnit } from '../../../actions/logs';
 import {
+  filterByCaster,
   getPlayerName,
   calculateDamageTotalForAbility,
   getSpellsCast,
@@ -25,6 +28,15 @@ const Container = styled.div`
   padding: 30px 20px 70px 20px;
   margin: 0 auto;
   min-height: calc(100vh - 255px);
+`;
+
+const Grid = styled.div`
+  display: block;
+`;
+
+const Row = styled.div`
+  display: flex;
+  flex-wrap: wrap;
 `;
 
 const SpellContainer = styled.div`
@@ -164,16 +176,16 @@ class DamageDetails extends Component {
         key: 'overview', route: `/log-overview/${log._id}?type=overview`, name: 'Overview', disabled: false,
       },
       {
-        key: 'damage-done', route: `/log-overview/${log._id}?type=damage-done`, name: 'Damage Done', disabled: false,
+        key: 'damage-done', route: `/damage-details/${log._id}?player=${query.player}&type=damage-done`, name: 'Damage Done', disabled: false,
       },
       {
-        key: 'healing-done', route: `/log-overview/${log._id}?type=healing-done`, name: 'Healing Done', disabled: false,
+        key: 'healing-done', route: `/healing-details/${log._id}?player=${query.player}&type=healing-done`, name: 'Healing Done', disabled: false,
       },
       {
-        key: 'damage-taken', route: `/log-overview/${log._id}?type=overview`, name: 'Damage Taken', disabled: true,
+        key: 'damage-taken', route: `/damage-taken-details/${log._id}?player=${query.player}&type=overview`, name: 'Damage Taken', disabled: true,
       },
       {
-        key: 'deaths', route: `/log-overview/${log._id}?type=overview`, name: 'Deaths', disabled: true,
+        key: 'deaths', route: `/deaths-details/${log._id}?player=${query.player}&type=overview`, name: 'Deaths', disabled: true,
       },
     ];
 
@@ -189,7 +201,7 @@ class DamageDetails extends Component {
             }}
           />
         ) : (
-          <div>
+          <Grid>
             <PlayerHeader
               player={getPlayerName(log.name)}
               image={this.getPlayerClass(log.raw, getPlayerName(log.name))}
@@ -197,15 +209,24 @@ class DamageDetails extends Component {
               date={moment(log.date).format('MMMM DD, YYYY h:mm A')}
             />
             <SubNavbar links={links} current={query.type} />
-            <h5>Damage Done</h5>
-            <Table
-              data={createRowOutput(log.damage, [constants.complimentColor, constants.compliment2Color])}
-              cells={5}
-              cellWidth={['100px', '30%', '30px', '30px', '30px']}
-              maxHeight="inherit"
-              headers={['Name', 'Amount', 'Casts', 'Avg Hit', 'Crit %']}
-            />
-          </div>
+            <ChipBar player={query.player} id={log._id} type={query.type} />
+            <div style={{ marginBottom: '10px' }}>
+              <DamageDoneChart
+                damage={filterByCaster(log.damage, query.player)}
+                player={getPlayerName(log.name)}
+              />
+            </div>
+            <Row>
+              <h5>Damage Done</h5>
+              <Table
+                data={createRowOutput(log.damage, [constants.complimentColor, constants.compliment2Color])}
+                cells={5}
+                cellWidth={['100px', '30%', '30px', '30px', '30px']}
+                maxHeight="inherit"
+                headers={['Name', 'Amount', 'Casts', 'Avg Hit', 'Crit %']}
+              />
+            </Row>
+          </Grid>
         )}
       </Container>
     );

--- a/src/components/Log/DamageDone/DamageDone.jsx
+++ b/src/components/Log/DamageDone/DamageDone.jsx
@@ -101,7 +101,7 @@ const DamageDone = ({ log, success, player }) => (
           <Table
             data={createRowOutput(log.damage, log.damageCasters, false, log._id, 'damage', [constants.complimentColor, constants.compliment2Color])}
             cells={3}
-            cellWidth={[2, 8, 2]}
+            cellWidth={['100px', '40%', '30px']}
             maxHeight="inherit"
             headers={['Name', 'Amount', 'DPS']}
           />

--- a/src/components/Log/HealingDone/HealingDone.jsx
+++ b/src/components/Log/HealingDone/HealingDone.jsx
@@ -101,7 +101,7 @@ const HealingDone = ({ log, success, player }) => (
           <Table
             data={createRowOutput(log.healing, log.healingCasters, false, log._id, 'healing', [constants.compliment2Color, constants.complimentColor])}
             cells={3}
-            cellWidth={[2, 8, 2]}
+            cellWidth={['100px', '40%', '30px']}
             maxHeight="inherit"
             headers={['Name', 'Amount', 'HPS']}
           />

--- a/src/components/Visualizations/DamageDoneChart/DamageDoneChart.jsx
+++ b/src/components/Visualizations/DamageDoneChart/DamageDoneChart.jsx
@@ -9,6 +9,7 @@ import {
   Area,
   ResponsiveContainer,
 } from 'recharts';
+import constants from '../../constants';
 
 const TooltipContent = ({ payload }) => {
   const data = payload && payload[0] && payload[0].payload;
@@ -70,9 +71,9 @@ class DamageDoneChart extends Component {
               bottom: 0
             }}
           >
-            <XAxis dataKey="time" stroke="#67737D" />
-            <YAxis stroke="#67737D" />
-            <CartesianGrid stroke="#505050" strokeWidth={1} opacity={0.5} />
+            <XAxis dataKey="time" stroke={constants.disabledColor} />
+            <YAxis stroke={constants.disabledColor} />
+            <CartesianGrid stroke={constants.highlightColor} strokeWidth={1} opacity={0.5} />
             <Tooltip content={<TooltipContent />} />
             <Area
               type="monotone"

--- a/src/components/Visualizations/HealingDoneChart/HealingDoneChart.jsx
+++ b/src/components/Visualizations/HealingDoneChart/HealingDoneChart.jsx
@@ -9,6 +9,7 @@ import {
   Area,
   ResponsiveContainer,
 } from 'recharts';
+import constants from '../../constants';
 
 const TooltipContent = ({ payload }) => {
   const data = payload && payload[0] && payload[0].payload;
@@ -70,9 +71,9 @@ class HealingDoneChart extends Component {
               bottom: 0,
             }}
           >
-            <XAxis dataKey="time" stroke="#67737D" />
-            <YAxis stroke="#67737D" />
-            <CartesianGrid stroke="#505050" strokeWidth={1} opacity={0.5} />
+            <XAxis dataKey="time" stroke={constants.disabledColor} />
+            <YAxis stroke={constants.disabledColor} />
+            <CartesianGrid stroke={constants.highlightColor} strokeWidth={1} opacity={0.5} />
             <Tooltip content={<TooltipContent />} />
             <Area
               type="monotone"

--- a/src/components/Visualizations/HealingDoneChart/HealingDoneChart.jsx
+++ b/src/components/Visualizations/HealingDoneChart/HealingDoneChart.jsx
@@ -77,9 +77,9 @@ class HealingDoneChart extends Component {
             <Area
               type="monotone"
               dataKey="rHealing"
-              stroke="#42f4d4"
+              stroke="#1bec83"
               fillOpacity={0.2}
-              fill="#42f4d4"
+              fill="#1bec83"
             />
           </AreaChartRecharts>
         </ResponsiveContainer>

--- a/src/components/Visualizations/OverviewChart/OverviewChart.jsx
+++ b/src/components/Visualizations/OverviewChart/OverviewChart.jsx
@@ -95,9 +95,9 @@ class OverviewChart extends Component {
             <Area
               type="monotone"
               dataKey="rHealing"
-              stroke="#42f4d4"
+              stroke="#1bec83"
               fillOpacity={0.2}
-              fill="#42f4d4"
+              fill="#1bec83"
             />
             <Area
               type="monotone"

--- a/src/index.css
+++ b/src/index.css
@@ -19,12 +19,12 @@ body {
 }
 
 a {
-  color: #c0ffda;
+  color: #e6c3ff;
   text-decoration: none;
 }
 
 a:hover {
-  color: #FFFFFF;
+  color: #f5e7ff;
   text-decoration: underline;
 }
 


### PR DESCRIPTION
- Clicking on a unit name in the damage table will show details for their damage spread
- DPS graph is now viewable in the damage details view
- Ability to remove the player filter from damage details has been added
- Fixed various spacing issues in the tables layout